### PR TITLE
(documentation only) Add moveMouseSmooth's third parameter (speed) to docs

### DIFF
--- a/_posts/docs/2016-10-12-syntax.md
+++ b/_posts/docs/2016-10-12-syntax.md
@@ -15,7 +15,7 @@ lead_text: ''
 * [Mouse](/docs/syntax#mouse)
   * [setMouseDelay](/docs/syntax#setmousedelayms)
   * [moveMouse](/docs/syntax#movemousex-y)
-  * [moveMouseSmooth](/docs/syntax#movemousesmoothx-y)
+  * [moveMouseSmooth](/docs/syntax#movemousesmoothx-y-speed)
   * [mouseClick](/docs/syntax#mouseclickbutton-double)
   * [mouseToggle](/docs/syntax#mousetoggledown-button)
   * [dragMouse](/docs/syntax#dragmousex-y)
@@ -188,7 +188,7 @@ var robot = require("robotjs");
 robot.moveMouse(100, 100);
 {% endhighlight %}
 
-## moveMouseSmooth(x, y)
+## moveMouseSmooth(x, y, [speed])
 
 Moves mouse to x, y human like, with the mouse button up.
 
@@ -198,6 +198,7 @@ Moves mouse to x, y human like, with the mouse button up.
 --------|-----------------|-------------
 `x`| | None
 `y`| | None
+`speed`| Time to use as movement delay in milliseconds. | 3
 
 ## mouseClick([button], [double])
 


### PR DESCRIPTION
The third parameter was added in [this commit](https://github.com/octalmage/robotjs/commit/1fad4c86d37914b580e8fbaddaffbb15a97baa7a) (7 Feb 2019) by [prithvihv]() that allows users to optionally pass a third parameter to `mouseMoveSmooth` method.